### PR TITLE
Added option to disable "Next" button

### DIFF
--- a/streamlit_survey/pages.py
+++ b/streamlit_survey/pages.py
@@ -4,7 +4,9 @@ import streamlit as st
 
 
 class Pages(object):
-    def __init__(self, labels: Union[int, list], key="__Pages_curent", on_submit=None, progress_bar=True):
+    def __init__(self, labels: Union[int, list], key="__Pages_curent",
+                 on_submit=None, progress_bar=True,
+                 disable_next: bool = False):
         """
         Parameters
         ----------
@@ -14,6 +16,8 @@ class Pages(object):
             Key to use to store the current page in Streamlit's session state
         on_submit: Callable
             Callback to call when the user clicks the submit button
+        disable_next: bool
+            Whether to have the "Next" button disabled by default
 
         Example
         -------
@@ -31,6 +35,7 @@ class Pages(object):
         self.current_page_key = key
         self.on_submit = on_submit
         self.progress_bar = progress_bar
+        self.disable_next = disable_next
 
     def update(self, value):
         """
@@ -122,7 +127,7 @@ class Pages(object):
                     type="primary",
                     use_container_width=True,
                     on_click=self.next,
-                    disabled=self.current == self.n_pages - 1,
+                    disabled=self.current == self.n_pages - 1 or self.disable_next,
                     key=f"{self.current_page_key}_btn_next",
                 )
         if self.progress_bar:

--- a/streamlit_survey/streamlit_survey.py
+++ b/streamlit_survey/streamlit_survey.py
@@ -101,7 +101,7 @@ class StreamlitSurvey:
 
     BASE_NAME = "__streamlit-survey-data"
 
-    def __init__(self, label: str = "", data: dict = None, auto_id: bool = True):
+    def __init__(self, label: str = "", data: dict = None, auto_id: bool = True, disable_next: bool = False):
         """
         Parameters
         ----------
@@ -111,6 +111,8 @@ class StreamlitSurvey:
             Dictionary containing survey questions and answers
         auto_id: bool
             Whether to automatically number survey questions
+        disable_next: bool
+            Whether to have the "Next" button disabled by default
         """
         self.data_name = self.BASE_NAME + "_" + label
         if data is None:
@@ -121,6 +123,7 @@ class StreamlitSurvey:
         self.label = label
         self.auto_id = auto_id
         self.data = data
+        self.disable_next = disable_next
 
         self._components = []  # Active (currently displayed) survey components
 
@@ -175,7 +178,7 @@ class StreamlitSurvey:
         Pages
             Pages object
         """
-        return Pages(index, key=self.data_name + "_Pages_" + label, on_submit=on_submit)
+        return Pages(index, key=self.data_name + "_Pages_" + label, on_submit=on_submit, disable_next=self.disable_next)
 
     def to_json(self, path: Optional[PathLike] = None) -> Optional[str]:
         """


### PR DESCRIPTION
This PR adds the option to disable the "Next" button of a page.

The `Page` object now takes an optional `disable_next` argument (which defaults to `False`). If `True`, the "Next" button will be grayed out.

To enable a disabled button, one can simply do `page.disable_next = False`.

The `disable_next` argument is now exposed in the main `StreamlitSurvey` class too.

TODO: Tests and documentation 😅 